### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/con-cis/project-exercisetracker-ts/security/code-scanning/2](https://github.com/con-cis/project-exercisetracker-ts/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow in `.github/workflows/node.js.yml`. The minimal starting point for most CI workflows where no API calls requiring write permissions are present is `contents: read`. This limits the GITHUB_TOKEN used by the workflow to only read the repository contents, preventing it from performing write operations (such as modifying files, pushing code, or editing releases). The permissions block should be placed either globally (before `jobs:`) or per job if different jobs require different permissions. Here, the simplest and safest fix is to add it at the top-level, right after the `name:` block and before `on:`. No other code/import changes are required, as this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
